### PR TITLE
Delete old security token storage

### DIFF
--- a/unpublished/project_kit/lib/src/utils/auth_token_handler/security_token_storage.dart
+++ b/unpublished/project_kit/lib/src/utils/auth_token_handler/security_token_storage.dart
@@ -46,8 +46,6 @@ bool userAuthorized(UserAuthorizedRef ref) {
 @Riverpod(keepAlive: true)
 class SecurityTokenStorage extends _$SecurityTokenStorage
     implements IRef, TokenStorage<AuthToken> {
-  @Deprecated('Use _encryptedStorage instead')
-  static const _storage = FlutterSecureStorage();
   static const _encryptedStorage = FlutterSecureStorage(
     aOptions: AndroidOptions(
       encryptedSharedPreferences: true,
@@ -61,7 +59,6 @@ class SecurityTokenStorage extends _$SecurityTokenStorage
   Future<AuthToken?> build() async {
     try {
       final token = await read();
-
       return token;
     } catch (_) {
       return null;
@@ -73,27 +70,16 @@ class SecurityTokenStorage extends _$SecurityTokenStorage
     await _encryptedStorage.delete(key: _refreshKey);
     await _encryptedStorage.delete(key: _accessKey);
     await _encryptedStorage.delete(key: _userId);
-    await _storage.delete(key: _refreshKey);
-    await _storage.delete(key: _accessKey);
-    await _storage.delete(key: _userId);
     setData(null);
   }
 
   @override
   Future<AuthToken?> read() async {
-    String? refreshToken = await _encryptedStorage.read(key: _refreshKey);
-    String? accessToken = await _encryptedStorage.read(key: _accessKey);
+    final refreshToken = await _encryptedStorage.read(key: _refreshKey);
+    final accessToken = await _encryptedStorage.read(key: _accessKey);
     final userId = await _encryptedStorage.read(key: _userId);
 
-    if (refreshToken == null || accessToken == null) {
-      refreshToken = await _storage.read(key: _refreshKey);
-      accessToken = await _storage.read(key: _accessKey);
-      if (refreshToken == null || accessToken == null) {
-        return null;
-      }
-      await _encryptedStorage.write(key: _refreshKey, value: refreshToken);
-      await _encryptedStorage.write(key: _accessKey, value: accessToken);
-    }
+    if (accessToken == null || refreshToken == null) return null;
 
     return AuthToken(
       accessToken: accessToken,

--- a/unpublished/project_kit/pubspec.yaml
+++ b/unpublished/project_kit/pubspec.yaml
@@ -10,8 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  riverpod_async_builder:
-    path: ../../riverpod_async_builder
+  riverpod_async_builder: ^0.0.3
 
   collection: ^1.18.0
   flutter_hooks: ^0.20.5


### PR DESCRIPTION
Предлагаю убрать старый storage и оставить только encrypted. По идее, должно быть все ок, а также убрать всякие возможные проблемы с двумя storage.  (Сегодня установил с ГП прилу - была ошибка,  unwrap key failed и после, что не может дешифровать. Мб связано с тем, что используем два стореджа, в ишью прочитал, так понял, разраб написал, что должен быть только один инстанс FlutterSecureStorage на приложение. Мб из-за этого, мб нет. Но так хотя бы от этого избавимся и будем уверены, что не из-за этого).
Все уже должны были перейти на encryptedStorage, так что разлогина, по идее, быть не должно.