### PR TITLE
Восстановление персистенса переживает перезапуск build

### DIFF
--- a/unpublished/project_kit/lib/src/utils/persistence/persistence_mixin.dart
+++ b/unpublished/project_kit/lib/src/utils/persistence/persistence_mixin.dart
@@ -154,6 +154,7 @@ mixin PersistenceMixin<State> implements INotifier<State> {
 /// ```
 mixin AsyncPersistenceMixin<State> implements IAsyncNotifier<State> {
   bool _isInitialized = false;
+  bool _isRefreshScheduled = false;
   String? _storageId;
   late String _storageKey = runtimeType.toString();
   PersistenceStorage get _storage => PersistenceStorage.storage;
@@ -190,23 +191,36 @@ mixin AsyncPersistenceMixin<State> implements IAsyncNotifier<State> {
 
     final data = _storage.read(key: _storageKey, id: _storageId);
 
-    listenSelf((_, next) => scheduleMicrotask(() {
-          if (next is! AsyncData<State>) return;
-          final data = next.value == null ? null : _toJson(next.value);
-          _storage.write(key: _storageKey, id: _storageId, value: data);
-        }));
+    listenSelf((_, next) {
+      // Восстановление израсходовано только тогда, когда проход build довёл
+      // своё значение до состояния. Асинхронный build перезапускается сколько
+      // угодно раз до своего завершения, и результат прерванного прохода
+      // выбрасывают: гаси флаг по факту чтения записи - и следующий проход
+      // останется без неё, соберёт состояние из фолбэка, а фолбэк уедет на
+      // диск поверх сохранённых данных.
+      if (next is AsyncData<State>) _isInitialized = true;
+
+      scheduleMicrotask(() {
+        if (next is! AsyncData<State>) return;
+        final data = next.value == null ? null : _toJson(next.value);
+        _storage.write(key: _storageKey, id: _storageId, value: data);
+      });
+    });
     final isRefresh = state.isRefreshing || state.isReloading;
 
     if (enabled && data != null && !_isInitialized && !isRefresh) {
       try {
-        _isInitialized = true;
         // Нужно предварительно пеобразовать json, т.к. иначе дарт сам не преобразует
         // внутренние модели из Map в Map<String, dynamic> и выбросит
         // type '_Map<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>' in type cast
         final json = jsonDecode(jsonEncode(data));
         final map = Map<String, dynamic>.from(json);
 
-        if (updateAfterFirstBuild) {
+        // Прерванный проход читает запись заново, поэтому сюда можно зайти
+        // несколько раз за одну инициализацию - обновление же остаётся
+        // одноразовым, как и обещает имя параметра.
+        if (updateAfterFirstBuild && !_isRefreshScheduled) {
+          _isRefreshScheduled = true;
           Future(() async {
             if (!ref.mounted) return;
             final futureOr = build();

--- a/unpublished/project_kit/test/persistence_mixin_test.dart
+++ b/unpublished/project_kit/test/persistence_mixin_test.dart
@@ -169,6 +169,83 @@ class _AsyncUpdateNotifier extends AsyncNotifier<_TestState>
 }
 
 // ---------------------------------------------------------------------------
+// Async notifier с зависимостью, объявленной до первого await
+// ---------------------------------------------------------------------------
+
+final _depProvider = NotifierProvider<_DepNotifier, int>(_DepNotifier.new);
+
+class _DepNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void bump() => state = state + 1;
+}
+
+/// Держит первый проход build подвисшим, пока тест меняет зависимость.
+Completer<void>? _firstPassGate;
+
+final _asyncWatchingProvider =
+    AsyncNotifierProvider<_AsyncWatchingNotifier, _TestState>(
+  _AsyncWatchingNotifier.new,
+);
+
+class _AsyncWatchingNotifier extends AsyncNotifier<_TestState>
+    with AsyncPersistenceMixin<_TestState> {
+  int buildCount = 0;
+
+  @override
+  Future<_TestState> build() async {
+    buildCount++;
+    final isFirstPass = buildCount == 1;
+
+    ref.watch(_depProvider);
+
+    // Фолбэк выдумывает данные, а не идёт за ними заново - как у потребителей,
+    // которые хранят накопленное.
+    final restored = await persistentBuild(
+      () => state.value ?? const _TestState(0),
+      fromJson: _TestState.fromJson,
+    );
+
+    if (isFirstPass) await _firstPassGate?.future;
+
+    return restored;
+  }
+}
+
+final _asyncWatchingUpdateProvider =
+    AsyncNotifierProvider<_AsyncWatchingUpdateNotifier, _TestState>(
+  _AsyncWatchingUpdateNotifier.new,
+);
+
+class _AsyncWatchingUpdateNotifier extends AsyncNotifier<_TestState>
+    with AsyncPersistenceMixin<_TestState> {
+  int buildCount = 0;
+  int fallbackCallCount = 0;
+
+  @override
+  Future<_TestState> build() async {
+    buildCount++;
+    final isFirstPass = buildCount == 1;
+
+    ref.watch(_depProvider);
+
+    final restored = await persistentBuild(
+      () {
+        fallbackCallCount++;
+        return const _TestState(99);
+      },
+      fromJson: _TestState.fromJson,
+      updateAfterFirstBuild: true,
+    );
+
+    if (isFirstPass) await _firstPassGate?.future;
+
+    return restored;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -414,6 +491,96 @@ void main() {
       await notifier.clearData();
 
       expect(_storage.read(key: '_AsyncNotifier'), isNull);
+    });
+  });
+
+  group('Перезапуск build до его завершения', () {
+    test('восстановленная запись достаётся следующему проходу', () async {
+      _initStorage({
+        '_AsyncWatchingNotifier': {'value': 42},
+      });
+      _firstPassGate = Completer<void>();
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      // Первый проход читает запись и подвисает.
+      container.read(_asyncWatchingProvider);
+      // Зависимость меняется, пока он не дошёл до конца: его результат
+      // выбрасывают, и до состояния доходит только второй проход.
+      container.read(_depProvider.notifier).bump();
+      _firstPassGate!.complete();
+
+      final state = await container.read(_asyncWatchingProvider.future);
+
+      expect(container.read(_asyncWatchingProvider.notifier).buildCount, 2);
+      expect(state, const _TestState(42));
+    });
+
+    test('фолбэк не затирает запись в хранилище', () async {
+      _initStorage({
+        '_AsyncWatchingNotifier': {'value': 42},
+      });
+      _firstPassGate = Completer<void>();
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      container.read(_asyncWatchingProvider);
+      container.read(_depProvider.notifier).bump();
+      _firstPassGate!.complete();
+      await container.read(_asyncWatchingProvider.future);
+      await _pumpWrites();
+
+      expect(_storage.read(key: '_AsyncWatchingNotifier'), {'value': 42});
+    });
+
+    test('updateAfterFirstBuild остаётся одноразовым', () async {
+      _initStorage({
+        '_AsyncWatchingUpdateNotifier': {'value': 5},
+      });
+      _firstPassGate = Completer<void>();
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      container.read(_asyncWatchingUpdateProvider);
+      container.read(_depProvider.notifier).bump();
+      _firstPassGate!.complete();
+      await container.read(_asyncWatchingUpdateProvider.future);
+      await _pumpWrites();
+      await _pumpWrites();
+
+      final notifier =
+          container.read(_asyncWatchingUpdateProvider.notifier);
+      expect(notifier.buildCount, 2);
+      expect(
+        notifier.fallbackCallCount,
+        1,
+        reason: 'обновление после первого build не должно удваиваться',
+      );
+      expect(
+        container.read(_asyncWatchingUpdateProvider),
+        isA<AsyncData<_TestState>>()
+            .having((d) => d.value, 'value', const _TestState(99)),
+      );
+    });
+  });
+
+  group('Ручное обновление провайдера', () {
+    test('не подставляет запись с диска вместо свежих данных', () async {
+      _initStorage({
+        '_AsyncNotifier': {'value': 42},
+      });
+      final container = ProviderContainer.test();
+      addTearDown(container.dispose);
+
+      expect(await container.read(_asyncProvider.future), const _TestState(42));
+
+      container.invalidate(_asyncProvider);
+
+      expect(
+        await container.read(_asyncProvider.future),
+        const _TestState(0),
+        reason: 'принудительное обновление обязано звать build, а не кеш',
+      );
     });
   });
 


### PR DESCRIPTION
## Зачем

Флаг «уже восстановили» в `AsyncPersistenceMixin` взводился в момент чтения записи из хранилища. Асинхронный `build` перезапускается сколько угодно раз до своего завершения, и результат прерванного прохода выбрасывают - значит запись доставалась проходу, которого никто не увидит, а следующий собирал состояние из фолбэка потребителя.

Потребителю, чей фолбэк выдумывает данные вместо похода за ними заново, это стоит сохранённых данных: фолбэк дальше уезжает на диск поверх записи. Поймано на списке недавних локаций в blancvpn - он терялся на каждом холодном старте, потому что его зависимость приезжала из ещё грузящегося соседа и перезапускала build ровно в этом окне.

## Что поменялось

Флаг взводится в `listenSelf`, когда проход довёл своё значение до состояния, а не по факту чтения записи. Прерванный проход читает запись заново и собирает состояние из неё.

Из этого следует второе: раз в ветку восстановления можно зайти несколько раз за одну инициализацию, `updateAfterFirstBuild` получил отдельный guard. Без него обновление после первого build удваивалось - это видно в тесте, он краснеет на старом коде значением 2 вместо 1.

Остальное поведение не тронуто намеренно: запись каждого принятого состояния на диск, пропуск восстановления при `ref.refresh`/`invalidate` (условие `!isRefresh`), подмена восстановленного значения результатом сетевого запроса. Синхронный `PersistenceMixin` не менялся - его `build` посередине не прервёшь.

## Тесты

Четыре новых, все красные на текущей ветке:

- восстановленная запись достаётся следующему проходу (было `TestState(0)` вместо `TestState(42)`);
- фолбэк не затирает запись в хранилище (на диске оказывался `{'value': 0}`);
- `updateAfterFirstBuild` остаётся одноразовым (было 2 вызова);
- ручное обновление провайдера не подставляет запись с диска - страховка на то, что правка не сломала намеренный `!isRefresh`.

Прогон целиком: 19/19 зелёные.